### PR TITLE
inc-rename not working?

### DIFF
--- a/nvim/lua/plugins/lsp.lua
+++ b/nvim/lua/plugins/lsp.lua
@@ -9,7 +9,7 @@ Plugin.dependencies = {
   { "mason-org/mason.nvim", opts = {}, cmd = { "Mason" } },
   { "mason-org/mason-lspconfig.nvim", opts = {} },
   { "stevearc/conform.nvim", opts = {} },
-  { "smjonas/inc-rename.nvim" },
+  -- { "smjonas/inc-rename.nvim" }, -- not working?
   { "stevearc/conform.nvim" },
   { "zapling/mason-conform.nvim" },
 }
@@ -55,7 +55,7 @@ function Plugin.config()
     },
   })
 
-  require("inc_rename").setup({ preview_empty_name = true })
+  -- require("inc_rename").setup({ preview_empty_name = true })
 
   vim.api.nvim_create_autocmd("LspAttach", {
     desc = "LSP actions",


### PR DESCRIPTION
seems to work for lua-ls but not pyright?

```
vim.schedule callback: ...vim/HEAD-684be73/share/nvim/runtime/lua/vim/lsp/util.lua:411: change_annotations must be provided for annotated text edits
stack traceback:
	[C]: in function 'assert'
	...vim/HEAD-684be73/share/nvim/runtime/lua/vim/lsp/util.lua:411: in function 'apply_text_edits'
	...vim/HEAD-684be73/share/nvim/runtime/lua/vim/lsp/util.lua:527: in function 'apply_text_document_edit'
	...vim/HEAD-684be73/share/nvim/runtime/lua/vim/lsp/util.lua:709: in function 'apply_workspace_edit'
	.../share/nvim/lazy/inc-rename.nvim/lua/inc_rename/init.lua:533: in function 'handler'
	...m/HEAD-684be73/share/nvim/runtime/lua/vim/lsp/client.lua:726: in function ''
	vim/_editor.lua: in function <vim/_editor.lua:0>
```